### PR TITLE
Fix typo durations

### DIFF
--- a/lib/phoenix_web_profiler/live/toolbar_live.ex
+++ b/lib/phoenix_web_profiler/live/toolbar_live.ex
@@ -50,7 +50,7 @@ defmodule PhoenixWeb.Profiler.ToolbarLive do
     # Usually this occurs after a node has been restarted and
     # a request is received for a stale token.
     assign(socket, %{
-      duration: nil,
+      durations: nil,
       request: %{
         status_code: ":|",
         status_phrase: "No Profiler Session (refresh)",


### PR DESCRIPTION
[error] GenServer #PID<0.488.0> terminating
** (ArgumentError) assign @durations not available in template.