### PR TITLE
Move reduce motion to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ The following options are available:
   injected for the toolbar. Expects a keyword list of atom keys and
   string values. Defaults to `[]`.
 
+* `:reduce_motion` - When set to `true`, disables all toolbar animations.
+  Defaults to `false`.
+
 ### 4. Configure LiveView
 
 > If LiveView is already installed in your app, you may skip this section.
@@ -161,12 +164,6 @@ live_dashboard "/dashboard",
     # additional pages...
   ]
 ```
-
-## Reduced motion toolbar options
-
-If a `PHOENIX_PROFILER_REDUCED_MOTION` environment variable is set,
-`PhoenixProfiler` will disable all toolbar animations. The value of the
-environment variable is not evaluated.
 
 <!-- MDOC -->
 

--- a/lib/phoenix_profiler/plug.ex
+++ b/lib/phoenix_profiler/plug.ex
@@ -91,13 +91,13 @@ defmodule PhoenixProfiler.Plug do
   defp debug_toolbar_assets_tag(conn, profile, config) do
     try do
       if Code.ensure_loaded?(PhoenixProfiler.ToolbarLive) do
-        motion_class = if System.get_env("PHOENIX_PROFILER_REDUCED_MOTION"), do: "no-motion"
-
         toolbar_attrs =
           case config[:toolbar_attrs] do
             attrs when is_list(attrs) -> attrs
             _ -> []
           end
+
+        motion_class = if config[:reduce_motion], do: "no-motion"
 
         attrs =
           Keyword.merge(


### PR DESCRIPTION
Seems like makes sense to keep all configuration in the same place, also renamed `reduced` -> `reduce` to keep same pattern as `enable`.