### PR TITLE
Rename page title to Phoenix Profilers

### DIFF
--- a/lib/phoenix_profiler/dashboard.ex
+++ b/lib/phoenix_profiler/dashboard.ex
@@ -19,7 +19,7 @@ if Code.ensure_loaded?(Phoenix.LiveDashboard) do
     alias PhoenixProfiler.Profiler
 
     @disabled_link "https://hexdocs.pm/phoenix_profiler"
-    @page_title "Phoenix profilers"
+    @page_title "Phoenix Profilers"
 
     @impl true
     def init(opts) do


### PR DESCRIPTION
To keep the same pattern as other pages (all initials in upper case) 👇🏻 

<img width="936" alt="Screen Shot 2022-01-22 at 2 33 36 PM" src="https://user-images.githubusercontent.com/36407/150653098-421c88b4-235f-45ba-8b46-6fcf3e1e59e4.png">

