### PR TITLE
Improve router helper display

### DIFF
--- a/lib/phoenix_profiler/toolbar/toolbar_live.html.leex
+++ b/lib/phoenix_profiler/toolbar/toolbar_live.html.leex
@@ -9,7 +9,7 @@
       </span>
       <%= if @request.router_helper do %>
       <span class="phxprof-toolbar-label"> @</span>
-      <span class="phxprof-toolbar-value"><%= @request.router_helper %></span>
+      <span class="phxprof-toolbar-value" title="<%= @request.router_helper %>"><%= @request.router_helper %></span>
       <% end %>
     </div>
     <div class="phxprof-toolbar-info">

--- a/priv/static/toolbar.css
+++ b/priv/static/toolbar.css
@@ -180,7 +180,7 @@
   height: var(--size-toolbar);
   margin-right: 0;
   white-space: nowrap;
-  max-width: 15%;
+  max-width: 20%;
 }
 
 .phxprof-toolbar-panel>a,


### PR DESCRIPTION
When the live action is longer than the available space it is impossible to read it. This small PR increases by 5% (maybe it can be even more, didn't want to go much past the previous value) the toolbar space which seems to improve the display of longer routes and also adds the title attribute to cover cases where the text is still cut allowing it to be displayed when hovering the text.