### PR TITLE
add compatibility with LiveView 0.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ This is all. Run `mix phx.server` and observe the toolbar on your browser reques
 
 ### 7. Add the profiler page on your LiveDashboard (optional)
 
+**The dashboard page is not compatible with `:live_dashboard ~> 0.8`**
+To disable the dashboard entirely, and allow the Profiler to compile,
+add `config :phoenix_profiler, use_dashboard?: false` to your config.
+
 Note this section is required for the LiveDashboard integration. If you are
 not using LiveDashboard, you may technically skip this step, although it is
 highly recommended that you

--- a/lib/phoenix_profiler/dashboard.ex
+++ b/lib/phoenix_profiler/dashboard.ex
@@ -1,4 +1,4 @@
-if Code.ensure_loaded?(Phoenix.LiveDashboard) do
+if Application.compile_env(:phoenix_profiler, :use_dashboard?, true) and Code.ensure_loaded?(Phoenix.LiveDashboard) do
   defmodule PhoenixProfiler.Dashboard do
     @moduledoc """
     [`LiveDashboard`](`Phoenix.LiveDashboard`) integration for PhoenixProfiler.

--- a/mix.exs
+++ b/mix.exs
@@ -41,8 +41,8 @@ defmodule PhoenixProfiler.MixProject do
     phoenix() ++
       [
         {:phoenix_html, ">= 3.2.0 and < 4.0.0"},
-        {:phoenix_live_view, "~> 0.18.0 or ~> 0.17.0 or ~> 0.16.0"},
-        {:phoenix_live_dashboard, "~> 0.7.0 or ~> 0.6.0 or ~> 0.5.0", optional: true},
+        {:phoenix_live_view, "~> 0.19.0 or ~> 0.18.0 or ~> 0.17.0 or ~> 0.16.0"},
+        {:phoenix_live_dashboard, "~> 0.8.0 or ~> 0.7.0 or ~> 0.6.0 or ~> 0.5.0", optional: true},
         # Dev Dependencies
         {:phoenix_live_reload, "~> 1.3", only: :dev},
         {:plug_cowboy, "~> 2.0", only: :dev},


### PR DESCRIPTION
It's currently impossible to use both PhoenixProfiler and LiveView 0.19

Add LiveView 0.19 and LiveDashBoard 0.8 to the list of compatible versions